### PR TITLE
Fix raw_fd_ostream constructor call for LLVM 4.0

### DIFF
--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -394,7 +394,7 @@ bool AFLCoverage::runOnModule(Module &M) {
         /* Print CFG */
         std::string cfgFileName = dotfiles + "/cfg." + funcName + ".dot";
         std::error_code EC;
-        raw_fd_ostream cfgFile(cfgFileName, EC);
+        raw_fd_ostream cfgFile(cfgFileName, EC, sys::fs::F_None);
         if (!EC) {
           WriteGraph(cfgFile, &F, true);
         }


### PR DESCRIPTION
Building aflgo master with LLVM 4.0 and Gold no longer works due to a modern `raw_fd_ostream` constructor being used. This constructor is not yet present in LLVM 4.0.

Rather than reverting to c2888eb as suggested in #57 I decided to check if another backwards compatible constructor could be used.

I have verified on my own fork that the constructor `raw_fd_ostream(StringRef Filename, std::error_code &EC, sys::fs::OpenFlags)` is present in LLVM 4.0 and the latest trunk as of writing.

[I used the same OpenFlags as LLVM trunk uses](https://github.com/llvm/llvm-project/blob/master/llvm/lib/Support/raw_ostream.cpp#L544-L546) for the 2-argument constructor, so there should not
be any change in functionality with this patch.

The updated constructor call uses `OpenFlags::F_None` instead of `OpenFlags::OF_None` to ensure backwards compatibility. The flag is present in both [LLVM 4.0](https://github.com/llvm/llvm-project/blob/release/4.x/llvm/include/llvm/Support/FileSystem.h#L625
) and [master](https://github.com/llvm/llvm-project/blob/73be415dd6dfce68aeba444359b5b296a3b11dce/llvm/include/llvm/Support/FileSystem.h#L763)

This should also fix #65 if I'm not mistaken.

If this patch is considered to be unsuitable for the project, feel free to close this PR.