### PR TITLE
fix the bug of normalized distance computations

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -4850,7 +4850,7 @@ static u32 calculate_score(struct queue_entry* q) {
   double power_factor = 1.0;
   if (q->distance > 0) {
 
-    double normalized_d = q->distance;
+    double normalized_d = 0; // when "max_distance == min_distance", we set the normalized_d to 0 so that we can sufficiently explore those testcases whose distance >= 0.
     if (max_distance != min_distance)
       normalized_d = (q->distance - min_distance) / (max_distance - min_distance);
 


### PR DESCRIPTION
We found that the normalized distance could be computed incorrectly when ``max_distance == min_distance`` (see issue #79 ).  When the ``max_distance`` is equal to the ``min_distance``, we observed that:
1. The fuzzer has generated some testcases whose distances are larger than 0;
2. The distances of these testcases are all the same, which means the testcases with smaller distances have not been generated. 

Thus, the directed fuzzing is in an early state. In this bug fix, we set the normalized distances of these testcases to 0, which allows the fuzzer to sufficiently explore these testcases.