### PR TITLE
Faster distance computation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,12 +28,13 @@ sudo apt-get update
 sudo apt-get install python3
 sudo apt-get install python3-dev
 sudo apt-get install python3-pip
+sudo apt-get install libboost-all-dev  # boost is not required if you use genDistance.sh in step 7
 sudo pip3 install --upgrade pip
 sudo pip3 install networkx
 sudo pip3 install pydot
 sudo pip3 install pydotplus
 ```
-3) Compile AFLGo fuzzer and LLVM-instrumentation pass
+3) Compile AFLGo fuzzer, LLVM-instrumentation pass and the distance calculator
 ```bash
 # Checkout source code
 git clone https://github.com/aflgo/aflgo.git
@@ -44,6 +45,10 @@ pushd $AFLGO
 make clean all 
 cd llvm_mode
 make clean all
+cd ..
+cd distance_calculator/
+cmake -G Ninja ./
+cmake --build ./
 popd
 ```
 4) Download subject (e.g., <a href="http://xmlsoft.org/" target="_blank">libxml2</a>) or just run [libxml2 fuzzing script](./scripts/fuzz/libxml2-ef709ce2.sh).
@@ -120,7 +125,8 @@ cat $TMP_DIR/BBnames.txt | rev | cut -d: -f2- | rev | sort | uniq > $TMP_DIR/BBn
 cat $TMP_DIR/BBcalls.txt | sort | uniq > $TMP_DIR/BBcalls2.txt && mv $TMP_DIR/BBcalls2.txt $TMP_DIR/BBcalls.txt
 
 # Generate distance ☕️
-$AFLGO/scripts/genDistance.sh $SUBJECT $TMP_DIR xmllint
+# $AFLGO/scripts/genDistance.sh is the original, but significantly slower, version
+$AFLGO/scripts/gen_distance_fast.py $SUBJECT $TMP_DIR xmllint
 
 # Check distance file
 echo "Distance values:"

--- a/distance_calculator/.clang-format
+++ b/distance_calculator/.clang-format
@@ -1,0 +1,66 @@
+# Generated from CLion C/C++ Code Style settings
+BasedOnStyle: Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignOperands: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+ColumnLimit: 100
+CompactNamespaces: false
+ContinuationIndentWidth: 8
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth: 4
+KeepEmptyLinesAtTheStartOfBlocks: true
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: All
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PointerAlignment: Right
+ReflowComments: false
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 0
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth: 4
+UseTab: Never

--- a/distance_calculator/CMakeLists.txt
+++ b/distance_calculator/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.10)
+project(distance_calculator)
+
+if (NOT CMAKE_BUILD_TYPE)
+    message(STATUS "Setting build type to 'Release' as none was specified.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE
+        STRING "Choose the type of build." FORCE)
+endif()
+set(CMAKE_CXX_FLAGS "-Wall -Wextra")
+set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_RELEASE "-O2 -march=native")
+
+
+find_package(Boost
+    REQUIRED
+    COMPONENTS program_options graph regex
+    )
+
+set(CMAKE_CXX_STANDARD 14)
+
+add_executable(distance_calculator main.cpp)
+target_link_libraries(distance_calculator ${Boost_LIBRARIES})

--- a/distance_calculator/main.cpp
+++ b/distance_calculator/main.cpp
@@ -1,0 +1,303 @@
+/**
+ * This is a C++ port of distance.py from
+ * https://github.com/aflgo/aflgo/blob/master/scripts/distance.py
+ *
+ * Loris Reiff <loris.reiff@liblor.ch>
+ */
+
+#include <boost/program_options.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <boost/graph/graphviz.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+namespace po = boost::program_options;
+namespace bo = boost;
+using std::cout;
+using std::cerr;
+using std::exception;
+using std::unordered_map;
+
+struct Vertex {
+    std::string name, label, shape;
+};
+
+struct Edge {
+    std::string label;
+};
+typedef bo::property<bo::graph_name_t, std::string> graph_p;
+typedef bo::adjacency_list<bo::vecS, bo::vecS, bo::directedS, Vertex, Edge, graph_p> graph_t;
+typedef bo::graph_traits<graph_t>::vertex_descriptor vertex_desc;
+
+static bool is_cg;
+
+static inline std::string node_name(const std::string &name) {
+    if (is_cg) {
+        return "{" + name + "}";
+    } else {
+        return "{" + name;
+    }
+}
+
+std::vector<vertex_desc> find_nodes(const graph_t &G, const std::string &name){
+    std::string n_name = node_name(name);
+    // memoization
+    static unordered_map<std::string, std::vector<vertex_desc>> mem;
+    auto ver_itr = mem.find(n_name);
+    if (ver_itr != mem.end()) return ver_itr->second;
+
+    std::vector<vertex_desc> ret;
+    bo::graph_traits<graph_t>::vertex_iterator vi, vi_end;
+    for (boost::tie(vi, vi_end) = vertices(G); vi != vi_end; ++vi) {
+        if(G[*vi].label.find(n_name) != std::string::npos) {
+            ret.push_back(*vi);
+        }
+    }
+    mem[n_name] = ret;
+    return ret;
+}
+
+// for testing
+vertex_desc _get_ver(const graph_t &G, const std::string &name){
+    bo::graph_traits<graph_t>::vertex_iterator vi, vi_end;
+    for (boost::tie(vi, vi_end) = vertices(G); vi != vi_end; ++vi) {
+        if(G[*vi].name.find(name) != std::string::npos) {
+            return *vi;
+        }
+    }
+    return -1;
+}
+
+inline void init_distances_from(const graph_t &G, vertex_desc from, std::vector<int> &dists) {
+    auto dist_pmap = bo::make_iterator_property_map(dists.begin(), get(bo::vertex_index, G));
+    auto vis = bo::make_bfs_visitor(bo::record_distances(dist_pmap, bo::on_tree_edge()));
+    bo::breadth_first_search(G, from, bo::visitor(vis));
+}
+
+void distance(
+    const graph_t &G,
+    const std::string &name,
+    const std::vector<vertex_desc> &targets,
+    std::ofstream &out,
+    unordered_map<std::string, double> &bb_distance
+) {
+    double distance = -1;
+    for (vertex_desc n : find_nodes(G, name)) {
+        std::vector<int> distances(bo::num_vertices(G), 0);
+        init_distances_from(G, n, distances);
+
+        double d = 0.0;
+        unsigned i = 0;
+        if (is_cg) {
+            for (vertex_desc t : targets) {
+                auto shortest = distances[t];           // shortest distance from n to t
+                if (shortest == 0 and n != t) continue; // not reachable
+                d += 1.0 / (1.0 + static_cast<double>(shortest));
+                ++i;
+            }
+        } else {
+            for (auto &bb_d_entry : bb_distance) {
+                double di = 0.0;
+                unsigned ii = 0;
+                for (auto t : find_nodes(G, bb_d_entry.first)) {
+                    auto shortest = distances[t];           // shortest distance from n to t
+                    if (shortest == 0 and n != t) continue; // not reachable
+                    di += 1.0 / (1.0 + 10 * bb_d_entry.second + static_cast<double>(shortest));
+                    ++ii;
+                }
+                if (ii != 0) {
+                    d += di / static_cast<double>(ii);
+                    ++i;
+                }
+            }
+        }
+        double tmp = static_cast<double>(i) / d;
+        if (d != 0 and (distance == -1 or distance > tmp)) {
+            distance = tmp;
+        }
+    }
+
+    if (distance != -1) {
+        out << name << "," << bo::lexical_cast<std::string>(distance) << "\n";
+    }
+}
+
+std::vector<vertex_desc> cg_calculation(
+    graph_t &G,
+    std::ifstream &target_stream
+) {
+    cout << "Loading targets..\n";
+    std::vector<vertex_desc> targets;
+    for (std::string line; getline(target_stream, line); ) {
+        bo::trim(line);
+        for (auto t : find_nodes(G, line)) {
+            targets.push_back(t);
+        }
+    }
+    if (targets.empty()) {
+        cout << "No targets available\n";
+        exit(0);
+    }
+    return targets;
+}
+
+std::vector<vertex_desc> cfg_calculation(
+    graph_t &G,
+    std::ifstream &targets_stream,
+    std::ifstream &cg_distance_stream,
+    std::ifstream &cg_callsites_stream,
+    unordered_map<std::string, double> &cg_distance,
+    unordered_map<std::string, double> &bb_distance
+) {
+    std::vector<vertex_desc> targets;
+    for (std::string line; getline(cg_distance_stream, line); ) {
+        bo::trim(line);
+        std::vector<std::string> splits;
+        bo::algorithm::split(splits, line, bo::is_any_of(","));;
+        assert(splits.size() == 2);
+        cg_distance[splits[0]] = std::stod(splits[1]);
+    }
+    if (cg_distance.empty()) {
+        cerr << "Call graph distance file is empty.\n";
+        exit(0);
+    }
+
+    for (std::string line; getline(cg_callsites_stream, line); ) {
+        bo::trim(line);
+        std::vector<std::string> splits;
+        bo::algorithm::split(splits, line, bo::is_any_of(","));;
+        assert(splits.size() == 2);
+        if (not find_nodes(G, splits[0]).empty()) {
+            if (cg_distance.find(splits[1]) != cg_distance.end()) {
+                if (bb_distance.find(splits[0]) != bb_distance.end()) {
+                    if (bb_distance[splits[0]] > cg_distance[splits[1]]) {
+                        bb_distance[splits[0]] = cg_distance[splits[1]];
+                    }
+                } else {
+                    bb_distance[splits[0]] = cg_distance[splits[1]];
+                }
+            }
+        }
+    }
+    cout << "Adding target BBs (if any)..\n";
+    for (std::string line; getline(targets_stream, line); ) {
+        bo::trim(line);
+        std::vector<std::string> splits;
+        bo::algorithm::split(splits, line, bo::is_any_of("/"));;
+        size_t found = line.find_last_of('/');
+        if (found != std::string::npos)
+            line = line.substr(found+1);
+        if (not find_nodes(G, splits[0]).empty()) {
+            bb_distance[line] = 0.0;
+            cout << "Added target BB " << line << "!\n";
+        }
+    }
+    return targets;
+}
+
+std::ifstream open_file(const std::string &filename) {
+    std::ifstream filestream(filename);
+    if (not filestream) {
+        cerr << "Error: " << strerror(errno);
+        exit(1);
+    }
+    return filestream;
+}
+
+int main(int argc, char *argv[]) {
+    po::variables_map vm;
+    try {
+        po::options_description desc("AFLGo distance calculator Port");
+        desc.add_options()
+                ("help,h", "produce help message")
+                ("dot,d", po::value<std::string>()->required(), "Path to dot-file representing the "
+                                                           "graph.")
+                ("targets,t", po::value<std::string>()->required(), "Path to file specifying Target"
+                                                                    " nodes.")
+                ("out,o", po::value<std::string>()->required(), "Path to output file containing "
+                                                                "distance for each node.")
+                ("names,n", po::value<std::string>()->required(), "Path to file containing name for"
+                                                                  " each node.")
+                ("cg_distance,c", po::value<std::string>(), "Path to file containing call graph "
+                                                            "distance.")
+                ("cg_callsites,s", po::value<std::string>(), "Path to file containing mapping "
+                                                             "between basic blocks and called "
+                                                             "functions.")
+                ;
+
+        po::store(po::parse_command_line(argc, argv, desc), vm);
+        po::notify(vm);
+
+        if (vm.count("help")) {
+            cout << desc << "\n";
+            return 0;
+        }
+    }
+    catch(exception& e) {
+        cerr << "error: " << e.what() << "\n";
+        return 1;
+    }
+    catch(...) {
+        cerr << "Exception of unknown type!\n";
+    }
+
+    std::ifstream dot = open_file(vm["dot"].as<std::string>());
+    cout << "Parsing " << vm["dot"].as<std::string>() << " ..\n";
+    graph_t graph(0);
+    bo::dynamic_properties dp(bo::ignore_other_properties);
+    dp.property("node_id", get(&Vertex::name,  graph));
+    dp.property("label",   get(&Vertex::label, graph));
+    dp.property("shape",   get(&Vertex::shape, graph));
+    dp.property("label",   get(&Edge::label,   graph));
+    boost::ref_property_map<graph_t *, std::string> gname(get_property(graph, bo::graph_name));
+    dp.property("label",    gname);
+
+    if (!read_graphviz(dot, graph, dp)) {
+        cerr << "Error while parsing " << vm["dot"].as<std::string>() << std::endl;
+        return 1;
+    }
+    is_cg = get_property(graph, bo::graph_name).find("Call graph") != std::string::npos;
+    cout << "Working on " << (is_cg ? "callgraph" : "control flow graph") << "\n";
+
+    std::ifstream targets_stream = open_file(vm["targets"].as<std::string>());
+    std::ifstream names = open_file(vm["names"].as<std::string>());
+    std::vector<vertex_desc> targets;
+    unordered_map<std::string, double> cg_distance;
+    unordered_map<std::string, double> bb_distance;
+
+    if (is_cg) {
+        targets = cg_calculation(graph, targets_stream);
+    } else {
+        if (not vm.count("cg_distance")) {
+            cerr << "error: the required argument for option '--cg_distance' is missing\n";
+            exit(1);
+        }
+        if (not vm.count("cg_callsites")) {
+            cerr << "error: the required argument for option '--cg_callsites' is missing\n";
+            exit(1);
+        }
+        std::ifstream cg_distance_stream = open_file(vm["cg_distance"].as<std::string>());
+        std::ifstream cg_callsites_stream = open_file(vm["cg_callsites"].as<std::string>());
+
+        std::vector<std::string> splits;
+        bo::algorithm::split(splits, vm["dot"].as<std::string>(), bo::is_any_of("."));;
+        std::string &caller = splits.end()[-2];
+        cout << "Loading cg_distance for function '" << caller << "'..\n";
+        targets = cfg_calculation(graph, targets_stream, cg_distance_stream,
+                                  cg_callsites_stream, cg_distance, bb_distance);
+    }
+
+    cout << "Calculating distance..\n";
+    std::ofstream outstream(vm["out"].as<std::string>());
+    for (std::string line; getline(names, line); ) {
+        bo::trim(line);
+        distance(graph, line, targets, outstream, bb_distance);
+    }
+
+    return 0;
+}

--- a/scripts/gen_distance_fast.py
+++ b/scripts/gen_distance_fast.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""
+Construct CG and calculate distances, similarly to genDistance.sh.
+The distance is parallelized and uses the compiled distance calculation
+version by default.
+"""
+import argparse
+import multiprocessing as mp
+import sys
+import subprocess
+from argparse import ArgumentTypeError as ArgTypeErr
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+
+STEP = 0
+STATE_FN = "state"
+DOT_DIR_NAME = "dot-files"
+CALLGRAPH_NAME = "callgraph.dot"
+PROJ_ROOT = Path(__file__).resolve().parent.parent
+DIST_BIN = PROJ_ROOT / "distance_calculator/distance_calculator"
+DIST_PY = PROJ_ROOT / "scripts/distance.py"
+
+
+def next_step(args):
+    global STEP
+    STEP += 1
+    fn = args.temporary_directory / STATE_FN
+    with fn.open("w") as f:
+        print(STEP, file=f)
+
+
+def get_resume(args):
+    fn = args.temporary_directory / STATE_FN
+    r = 0
+    try:
+        with fn.open("r") as f:
+            r = int(f.read())
+    except FileNotFoundError:
+        pass
+    return r
+
+
+def abort(args):
+    print(f"Failed in step {STEP}", file=sys.stderr)
+    log_p = args.temporary_directory / f"step{STEP}.log"
+    print(f"Check {log_p} for more information", file=sys.stderr)
+    sys.exit(1)
+
+
+def remove_repeated_lines(in_path, out_path):
+    lines_seen = set()
+    with out_path.open("w") as out, in_path.open("r") as in_f:
+        for line in in_f.readlines():
+            if line not in lines_seen:
+                out.write(line)
+                lines_seen.add(line)
+
+
+def merge_callgraphs(dots, outfilepath):
+    import networkx as nx
+    print(f"({STEP}) Integrating several call-graphs into one.")
+    G = nx.DiGraph()
+    for dot in dots:
+        G.update(nx.DiGraph(nx.drawing.nx_pydot.read_dot(dot)))
+    with outfilepath.open('w') as f:
+        nx.drawing.nx_pydot.write_dot(G, f)
+
+
+def opt_callgraph(args, binary):
+    print(f"({STEP}) Constructing CG for {binary}..")
+    dot_files = args.temporary_directory / DOT_DIR_NAME
+    cmd = ["opt", "-dot-callgraph", f"{binary}", "-o", "/dev/null"]
+    log_p = args.temporary_directory / f"step{STEP}.log"
+    with log_p.open("w") as f:
+        try:
+            subprocess.run(cmd, stderr=f, check=True, cwd=dot_files)
+        except subprocess.CalledProcessError:
+            abort(args)
+
+
+def construct_callgraph(args, binaries):
+    fuzzer = args.fuzzer_name
+    dot_files = args.temporary_directory / DOT_DIR_NAME
+    callgraph = dot_files / CALLGRAPH_NAME
+
+    if fuzzer:
+        tmp = next(args.binaries_directory.glob(f"{fuzzer.name}.0.0.*.bc"))
+        binaries = [tmp]
+
+    for binary in binaries:
+        opt_callgraph(args, binary)
+        remove_repeated_lines(
+                callgraph,
+                dot_files / f"callgraph.{binary.name}.dot")
+        callgraph.unlink()
+
+    # The goal is to have one file called "callgraph.dot"
+    if fuzzer:
+        cg = dot_files / f"callgraph.{binary.name}.dot"
+        cg.replace(callgraph)
+    else:
+        callgraphs = dot_files.glob("callgraph.*.dot")
+        merge_callgraphs(callgraphs, callgraph)
+    next_step(args)
+
+
+def exec_distance_prog(dot, targets, out, names, cg_distance=None,
+                       cg_callsites=None, py_version=False):
+    """
+    Args:
+        dot: Path to dot-file representing the graph.
+        targets: Path to file specifying Target nodes.
+        out: Path to output file containing distance for each node.
+        names: Path to file containing name for each node.
+        cg_distance: Path to file containing call-graph distance.
+        cg_callsites: Path to file containing mapping between basic blocks and
+            called functions.
+        py_version: If true, the python version is used.
+    """
+    prog = DIST_BIN if not py_version else DIST_PY
+    cmd = [prog,
+           "-d", dot,
+           "-t", targets,
+           "-o", out,
+           "-n", names]
+    if cg_distance is not None and cg_callsites is not None:
+        cmd.extend(["-c", cg_distance,
+                    "-s", cg_callsites])
+    devn = subprocess.DEVNULL
+    r = subprocess.run(cmd, stdout=devn, stderr=devn).returncode
+    if r != 0:
+        print("cfg distance calculator failed while calculating "
+              f"distance for {targets}.", file=sys.stderr)
+        sys.exit(-1)
+
+
+def dd_cleanup(cfg):
+    cmd = fr"""
+    awk '!a[$0]++' {cfg} > {cfg}.smaller.dot;
+    mv {cfg}.smaller.dot {cfg};
+    sed -i s/\\\\\"//g {cfg};
+    sed -i 's/\[.\"]//g' {cfg};
+    sed -i 's/\(^\s*[0-9a-zA-Z_]*\):[a-zA-Z0-9]*\( -> \)/\1\2/g' {cfg}
+    """
+    subprocess.run(cmd, shell=True)
+
+
+def merge_distance_files(cfg_cg_path, output):
+    with output.open('w') as f:
+        for dist in cfg_cg_path.glob("*.distances.txt"):
+            with dist.open("r") as df:
+                f.write(df.read())
+
+
+def calculating_distances(args):
+    print(f"({STEP}) Computing distance for callgraph")
+    dot_files = args.temporary_directory / DOT_DIR_NAME
+    bbcalls = args.temporary_directory / "BBcalls.txt"
+    bbnames = args.temporary_directory / "BBnames.txt"
+    fnames = args.temporary_directory / "Fnames.txt"
+    ftargets = args.temporary_directory / "Ftargets.txt"
+    callgraph = dot_files / CALLGRAPH_NAME
+    callgraph_distance = args.temporary_directory / "callgraph.distance.txt"
+
+    exec_distance_prog(
+            callgraph,
+            ftargets,
+            callgraph_distance,
+            fnames,
+            py_version=args.python_only)
+
+    # Helper
+    def calculate_cfg_distance_from_file(cfg: Path):
+        if cfg.stat().st_size == 0: return
+        dd_cleanup(cfg)     # for python version
+        outname = cfg.name.split('.')[-2] + ".distances.txt"
+        outpath = cfg.parent / outname
+        exec_distance_prog(
+                cfg,
+                bbtargets,
+                outpath,
+                bbnames,
+                callgraph_distance,
+                bbcalls,
+                py_version=args.python_only)
+    print(f"({STEP}) Computing distance for control-flow graphs (this might "
+          "take a while)")
+    with ThreadPoolExecutor(max_workers=mp.cpu_count()) as executor:
+        results = executor.map(calculate_cfg_distance_from_file,
+                               dot_files.glob("cfg.*.dot"))
+    print(f"({STEP}) Done computing distance for CFG")
+    merge_distance_files(
+            dot_files,
+            args.temporary_directory / "distance.cfg.txt")
+    next_step(args)
+
+
+def done(args):
+    fn = args.temporary_directory / STATE_FN
+    fn.unlink()
+    print(f"""
+----------[DONE]----------
+
+Now, you may wish to compile your sources with
+CC=\"{PROJ_ROOT}/afl-clang-fast\"
+CXX=\"{PROJ_ROOT}/afl-clang-fast++\"
+CFLAGS=\"$CFLAGS -distance=$(readlink -e $TMPDIR/distance.cfg.txt)\"
+CXXFLAGS=\"$CXXFLAGS -distance=$(readlink -e $TMPDIR/distance.cfg.txt)\"
+
+--------------------------
+""")
+
+
+# -- Argparse --
+def is_path_to_dir(path):
+    """Returns Path object when path is an existing directory"""
+    p = Path(path)
+    if not p.exists():
+        raise ArgTypeErr("path doesn't exist")
+    if not p.is_dir():
+        raise ArgTypeErr("not a directory")
+    return p
+# ----
+
+
+def main():
+    global STEP
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binaries_directory", metavar="binaries-directory",
+                        type=is_path_to_dir,
+                        help="Directory where binaries of 'subject' are "
+                             "located")
+    parser.add_argument("temporary_directory", metavar="temporary-directory",
+                        type=is_path_to_dir,
+                        help="Directory where dot files and target files are "
+                             "located")
+    parser.add_argument("fuzzer_name", metavar="fuzzer-name",
+                        nargs='?',
+                        help="Name of fuzzer binary")
+    parser.add_argument("-p" ,"--python-only",
+                        action="store_true",
+                        default=False,
+                        help="Use the python version for distance calculation")
+    args = parser.parse_args()
+
+    # Additional sanity checks
+    binaries = list(args.binaries_directory.glob("*.0.0.*.bc"))
+    if len(binaries) == 0:
+        parser.error("Couldn't find any binaries in folder "
+                     f"{args.binaries_directory}.")
+    if args.fuzzer_name:
+        tmp = args.binaries_directory.glob(f"{args.fuzzer_name}.0.0.*.bc")
+        args.fuzzer_name = args.binaries_directory / args.fuzzer_name
+        if not args.fuzzer_name.exists() or args.fuzzer_name.is_dir():
+            parser.error(f"Couldn't find {args.fuzzer}.")
+        if len(list(tmp)) == 0:
+            parser.error(f"Couldn't find bytecode for fuzzer {args.fuzzer} "
+                         f"in folder {args.binaries_directory}.")
+
+    STEP = get_resume(args)
+    if not STEP:
+        construct_callgraph(args, binaries),
+    calculating_distances(args),
+    done(args)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hi

I am using parts of AflGo for my master thesis. Since the distance computation was a bit slow for my use-case I rewrote it in C++. This version acts as drop-in replacement for `distance.py`. Furthermore, I replaced the `genDistance.sh` with a python script which calls the distance computation in parallel.
These modifications result in a significant speed up!

**Summary of optimizations:**
- Use C++ instead of python
- Use BFS instead of Dijkstra as graph is unweighted
- Parallelize computation