### PR TITLE
Bug fixes in fast distance computation

### DIFF
--- a/distance_calculator/main.cpp
+++ b/distance_calculator/main.cpp
@@ -40,7 +40,7 @@ static inline std::string node_name(const std::string &name) {
     if (is_cg) {
         return "{" + name + "}";
     } else {
-        return "{" + name;
+        return "{" + name + ":";
     }
 }
 
@@ -231,12 +231,11 @@ int main(int argc, char *argv[]) {
                 ;
 
         po::store(po::parse_command_line(argc, argv, desc), vm);
-        po::notify(vm);
-
         if (vm.count("help")) {
             cout << desc << "\n";
             return 0;
         }
+        po::notify(vm);
     }
     catch(exception& e) {
         cerr << "error: " << e.what() << "\n";

--- a/scripts/gen_distance_fast.py
+++ b/scripts/gen_distance_fast.py
@@ -159,6 +159,7 @@ def calculating_distances(args):
     bbcalls = args.temporary_directory / "BBcalls.txt"
     bbnames = args.temporary_directory / "BBnames.txt"
     fnames = args.temporary_directory / "Fnames.txt"
+    bbtargets = args.temporary_directory / "BBtargets.txt"
     ftargets = args.temporary_directory / "Ftargets.txt"
     callgraph = dot_files / CALLGRAPH_NAME
     callgraph_distance = args.temporary_directory / "callgraph.distance.txt"
@@ -189,6 +190,7 @@ def calculating_distances(args):
     with ThreadPoolExecutor(max_workers=mp.cpu_count()) as executor:
         results = executor.map(calculate_cfg_distance_from_file,
                                dot_files.glob("cfg.*.dot"))
+    for r in results: pass  # forward Exceptions
     print(f"({STEP}) Done computing distance for CFG")
     merge_distance_files(
             dot_files,

--- a/scripts/gen_distance_fast.py
+++ b/scripts/gen_distance_fast.py
@@ -171,11 +171,16 @@ def calculating_distances(args):
             fnames,
             py_version=args.python_only)
 
+    with callgraph.open("r") as f:
+        callgraph_dot = f.read()
+
     # Helper
     def calculate_cfg_distance_from_file(cfg: Path):
         if cfg.stat().st_size == 0: return
         dd_cleanup(cfg)     # for python version
-        outname = cfg.name.split('.')[-2] + ".distances.txt"
+        name = cfg.name.split('.')[-2]
+        if name not in callgraph_dot: return
+        outname = name + ".distances.txt"
         outpath = cfg.parent / outname
         exec_distance_prog(
                 cfg,


### PR DESCRIPTION
Hi @mboehme 

Today when I started porting AFLGo to llvm 11, I noticed that the `gen_distance_fast.py` script had a bug which made it fail. After fixing the bug I also noticed that, some erroneous lines were present in the final distance file, which I promptly fixed as well.

**How did that happen?**
Naturally, I tested #83. I did so as following:
I tested the the `distance_calculator` binary directly on some callgraphs and CFGs and compared it to the output of `distance.py`, after sorting (apart from some rounding differences they were the same). Then I ran `genDistance.sh` and `gen_distance_fast.py` on xmllint, et voilà the distance file matched. 
Now here's the catch, `gen_distance_fast.py` only recalculated the distances for the callgraph, but didn't produce any distance files for the CFGs, instead it merged the previous ones calculated by `genDistance.sh`. It didn't do so, because of an undefined variable (copy& paste mistake (a bit embarrassing...)). So why was there no exception? Because [ThreadPoolExecutor's map](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.map) only raises the exception once the returned result is accessed, which I didn't do as there was no need for it...

Sorry for any additional work caused.