### PR TITLE
LLVM 11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ifndef AFL_NO_X86
 test_build: afl-gcc afl-as afl-showmap
 	@echo "[*] Testing the CC wrapper and instrumentation output..."
 	unset AFL_USE_ASAN AFL_USE_MSAN; AFL_QUIET=1 AFL_INST_RATIO=100 AFL_PATH=. ./$(TEST_CC) $(CFLAGS) test-instr.c -o test-instr $(LDFLAGS)
-	echo 0 | ./afl-showmap -m none -q -o .test-instr0 ./test-instr
+	./afl-showmap -m none -q -o .test-instr0 ./test-instr < /dev/null
 	echo 1 | ./afl-showmap -m none -q -o .test-instr1 ./test-instr
 	@rm -f test-instr
 	@cmp -s .test-instr0 .test-instr1; DR="$$?"; rm -f .test-instr0 .test-instr1; if [ "$$DR" = "0" ]; then echo; echo "Oops, the instrumentation does not seem to be behaving correctly!"; echo; echo "Please ping <lcamtuf@google.com> to troubleshoot the issue."; echo; exit 1; fi

--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ The easiest way to use AFLGo is as patch testing tool in OSS-Fuzz. Here is our i
 * **AFLGO_PROFILING_FILE** -- When CFG-tracing is enabled, the data will be stored here.
 
 # How to instrument a Binary with AFLGo
-1) Install <a href="https://llvm.org/docs/CMake.html" target="_blank">LLVM</a> **4.0.0** with <a href="http://llvm.org/docs/GoldPlugin.html" target="_blank">Gold</a>-plugin. You can also follow <a href="https://github.com/aflgo/oss-fuzz/blob/master/infra/base-images/base-clang/checkout_build_install_llvm.sh" target="_blank">these</a> instructions or run [AFLGo building script](./scripts/build/aflgo-build.sh).
+1) Install <a href="https://llvm.org/docs/CMake.html" target="_blank">LLVM</a> **11.0.0** with <a href="http://llvm.org/docs/GoldPlugin.html" target="_blank">Gold</a>-plugin. You can also follow <a href="https://github.com/aflgo/oss-fuzz/blob/master/infra/base-images/base-clang/checkout_build_install_llvm.sh" target="_blank">these</a> instructions or run [AFLGo building script](./scripts/build/aflgo-build.sh).
 2) Install other prerequisite
 ```bash
 sudo apt-get update

--- a/llvm_mode/afl-llvm-pass.so.cc
+++ b/llvm_mode/afl-llvm-pass.so.cc
@@ -300,7 +300,7 @@ bool AFLCoverage::runOnModule(Module &M) {
     for (auto &F : M) {
 
       bool has_BBs = false;
-      std::string funcName = F.getName();
+      std::string funcName = F.getName().str();
 
       /* Black list of function names */
       if (isBlacklisted(&F)) {
@@ -368,7 +368,8 @@ bool AFLCoverage::runOnModule(Module &M) {
             Twine t(newname);
             SmallString<256> NameData;
             StringRef NameRef = t.toStringRef(NameData);
-            BB.setValueName(ValueName::Create(NameRef));
+            MallocAllocator Allocator;
+            BB.setValueName(ValueName::Create(NameRef, Allocator));
           }
 
           bbnames << BB.getName().str() << "\n";

--- a/scripts/build/aflgo-build.sh
+++ b/scripts/build/aflgo-build.sh
@@ -2,7 +2,7 @@
 set -e # exit on error
 
 # Build clang & LLVM
-LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git subversion python2.7 binutils-gold binutils-dev curl wget"
+LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git binutils-gold binutils-dev curl wget python3-distutils"
 apt-get install -y $LLVM_DEP_PACKAGES
 
 export CXX=g++
@@ -12,26 +12,26 @@ unset CXXFLAGS
 
 mkdir ~/build; cd ~/build
 mkdir llvm_tools; cd llvm_tools
-wget http://releases.llvm.org/4.0.0/llvm-4.0.0.src.tar.xz
-wget http://releases.llvm.org/4.0.0/cfe-4.0.0.src.tar.xz
-wget http://releases.llvm.org/4.0.0/compiler-rt-4.0.0.src.tar.xz
-wget http://releases.llvm.org/4.0.0/libcxx-4.0.0.src.tar.xz
-wget http://releases.llvm.org/4.0.0/libcxxabi-4.0.0.src.tar.xz
-tar xf llvm-4.0.0.src.tar.xz
-tar xf cfe-4.0.0.src.tar.xz
-tar xf compiler-rt-4.0.0.src.tar.xz
-tar xf libcxx-4.0.0.src.tar.xz
-tar xf libcxxabi-4.0.0.src.tar.xz
-mv cfe-4.0.0.src ~/build/llvm_tools/llvm-4.0.0.src/tools/clang
-mv compiler-rt-4.0.0.src ~/build/llvm_tools/llvm-4.0.0.src/projects/compiler-rt
-mv libcxx-4.0.0.src ~/build/llvm_tools/llvm-4.0.0.src/projects/libcxx
-mv libcxxabi-4.0.0.src ~/build/llvm_tools/llvm-4.0.0.src/projects/libcxxabi
+wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-11.0.0.src.tar.xz
+wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang-11.0.0.src.tar.xz
+wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/compiler-rt-11.0.0.src.tar.xz
+wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/libcxx-11.0.0.src.tar.xz
+wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/libcxxabi-11.0.0.src.tar.xz
+tar xf llvm-11.0.0.src.tar.xz
+tar xf clang-11.0.0.src.tar.xz
+tar xf compiler-rt-11.0.0.src.tar.xz
+tar xf libcxx-11.0.0.src.tar.xz
+tar xf libcxxabi-11.0.0.src.tar.xz
+mv clang-11.0.0.src ~/build/llvm_tools/llvm-11.0.0.src/tools/clang
+mv compiler-rt-11.0.0.src ~/build/llvm_tools/llvm-11.0.0.src/projects/compiler-rt
+mv libcxx-11.0.0.src ~/build/llvm_tools/llvm-11.0.0.src/projects/libcxx
+mv libcxxabi-11.0.0.src ~/build/llvm_tools/llvm-11.0.0.src/projects/libcxxabi
 
 mkdir -p build-llvm/llvm; cd build-llvm/llvm
 cmake -G "Ninja" \
       -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
       -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" \
-      -DLLVM_BINUTILS_INCDIR=/usr/include ~/build/llvm_tools/llvm-4.0.0.src
+      -DLLVM_BINUTILS_INCDIR=/usr/include ~/build/llvm_tools/llvm-11.0.0.src
 ninja; ninja install
 
 cd ~/build/llvm_tools
@@ -41,7 +41,7 @@ cmake -G "Ninja" \
       -DLLVM_USE_SANITIZER=Memory -DCMAKE_INSTALL_PREFIX=/usr/msan/ \
       -DLIBCXX_ENABLE_SHARED=OFF -DLIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON \
       -DCMAKE_BUILD_TYPE=Release -DLLVM_TARGETS_TO_BUILD="X86" \
-       ~/build/llvm_tools/llvm-4.0.0.src
+       ~/build/llvm_tools/llvm-11.0.0.src
 ninja cxx; ninja install-cxx
 
 # Install LLVMgold in bfd-plugins
@@ -52,7 +52,7 @@ cp /usr/local/lib/LLVMgold.so /usr/lib/bfd-plugins
 # install some packages
 export LC_ALL=C
 apt-get update
-apt install -y python-dev python3 python3-dev python3-pip autoconf automake libtool-bin python-bs4 libclang-4.0-dev
+apt install -y python-dev python3 python3-dev python3-pip autoconf automake libtool-bin python-bs4 # libclang-11.0-dev
 python3 -m pip install --upgrade pip
 python3 -m pip install networkx pydot pydotplus
 

--- a/scripts/build/aflgo-build.sh
+++ b/scripts/build/aflgo-build.sh
@@ -52,7 +52,7 @@ cp /usr/local/lib/LLVMgold.so /usr/lib/bfd-plugins
 # install some packages
 export LC_ALL=C
 apt-get update
-apt install -y python-dev python3 python3-dev python3-pip autoconf automake libtool-bin python-bs4 # libclang-11.0-dev
+apt install -y python-dev python3 python3-dev python3-pip autoconf automake libtool-bin python-bs4 libboost-all-dev # libclang-11.0-dev
 python3 -m pip install --upgrade pip
 python3 -m pip install networkx pydot pydotplus
 
@@ -62,4 +62,5 @@ export CC=clang
 cd /afl
 make clean all
 pushd llvm_mode; make clean all; popd
+pushd distance_calculator; cmake -G Ninja ./; cmake --build ./; popd
 export AFLGO=/afl

--- a/scripts/build/aflgo-build.sh
+++ b/scripts/build/aflgo-build.sh
@@ -2,8 +2,17 @@
 set -e # exit on error
 
 # Build clang & LLVM
-LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git binutils-gold binutils-dev curl wget python3-distutils"
+LLVM_DEP_PACKAGES="build-essential make cmake ninja-build git binutils-gold binutils-dev curl wget"
 apt-get install -y $LLVM_DEP_PACKAGES
+
+UBUNTU_VERSION=`cat /etc/os-release | grep VERSION_ID | cut -d= -f 2`
+UBUNTU_YEAR=`echo $UBUNTU_VERSION | cut -d. -f 1`
+UBUNTU_MONTH=`echo $UBUNTU_VERSION | cut -d. -f 2`
+
+if [[ "$UBUNTU_YEAR" > "16" || "$UBUNTU_MONTH" > "04" ]]
+then
+    apt-get install -y python3-distutils
+fi
 
 export CXX=g++
 export CC=gcc

--- a/scripts/build/aflgo-build.sh
+++ b/scripts/build/aflgo-build.sh
@@ -45,7 +45,7 @@ cmake -G "Ninja" \
 ninja cxx; ninja install-cxx
 
 # Install LLVMgold in bfd-plugins
-mkdir /usr/lib/bfd-plugins
+mkdir -p /usr/lib/bfd-plugins
 cp /usr/local/lib/libLTO.so /usr/lib/bfd-plugins
 cp /usr/local/lib/LLVMgold.so /usr/lib/bfd-plugins
 

--- a/scripts/distance.py
+++ b/scripts/distance.py
@@ -14,7 +14,7 @@ class memoize:
     self._cache = {}
 
   def __call__(self, *args):
-    if not isinstance(args, collections.Hashable):
+    if not isinstance(args, collections.abc.Hashable):
       return self._func(args)
 
     if args in self._cache:

--- a/scripts/genDistance.sh
+++ b/scripts/genDistance.sh
@@ -61,13 +61,14 @@ if [ $RESUME -le $STEP ]; then
     for binary in $(echo "$binaries"); do
 
       echo "($STEP) Constructing CG for $binary.."
-      while ! opt -dot-callgraph $binary.0.0.*.bc >/dev/null 2> $TMPDIR/step${STEP}.log ; do
+      prefix="$TMPDIR/dot-files/$(basename $binary)"
+      while ! opt -dot-callgraph $binary.0.0.*.bc -callgraph-dot-filename-prefix $prefix >/dev/null 2> $TMPDIR/step${STEP}.log ; do
         echo -e "\e[93;1m[!]\e[0m Could not generate call graph. Repeating.."
       done
 
       #Remove repeated lines and rename
-      awk '!a[$0]++' callgraph.dot > callgraph.$(basename $binary).dot
-      rm callgraph.dot
+      awk '!a[$0]++' $(basename $binary).callgraph.dot > callgraph.$(basename $binary).dot
+      rm $(basename $binary).callgraph.dot
     done
 
     #Integrate several call graphs into one
@@ -77,13 +78,14 @@ if [ $RESUME -le $STEP ]; then
   else
 
     echo "($STEP) Constructing CG for $fuzzer.."
-    while ! opt -dot-callgraph $fuzzer.0.0.*.bc >/dev/null 2> $TMPDIR/step${STEP}.log ; do
+    prefix="$TMPDIR/dot-files/$(basename $fuzzer)"
+    while ! opt -dot-callgraph $fuzzer.0.0.*.bc -callgraph-dot-filename-prefix $prefix >/dev/null 2> $TMPDIR/step${STEP}.log ; do
       echo -e "\e[93;1m[!]\e[0m Could not generate call graph. Repeating.."
     done
 
     #Remove repeated lines and rename
-    awk '!a[$0]++' callgraph.dot > callgraph.1.dot
-    mv callgraph.1.dot callgraph.dot
+    awk '!a[$0]++' $(basename $fuzzer).callgraph.dot > callgraph.dot
+    rm $(basename $fuzzer).callgraph.dot
 
   fi
 fi


### PR DESCRIPTION
Work in progress: Port AFLGo to LLVM 11.

### TODO:
- [x] Update build script
- [x] Make `afl-llvm-pass.so.cc` compile
- [x] Update `gen_distance_fast.py`
- [x] Update `genDistance.sh`
- [x] Have a look at build process as clang fails in compiling `afl-gcc` which isn't used anyway (afaik). Building with `make clean && AFL_NO_X86=1 make` works
- [x] Update README.md
- [x] Maybe something else
- [x] Testing
