### PR TITLE
Fix discrepancy between paper and implementation

### DIFF
--- a/distance_calculator/main.cpp
+++ b/distance_calculator/main.cpp
@@ -86,6 +86,11 @@ void distance(
     std::ofstream &out,
     unordered_map<std::string, double> &bb_distance
 ) {
+    if (not is_cg and bb_distance.find(name) != bb_distance.end()) {
+        out << name << "," << bo::lexical_cast<std::string>(10 * bb_distance[name]) << "\n";
+        return;
+    }
+
     double distance = -1;
     for (vertex_desc n : find_nodes(G, name)) {
         std::vector<int> distances(bo::num_vertices(G), 0);

--- a/scripts/distance.py
+++ b/scripts/distance.py
@@ -54,6 +54,12 @@ def find_nodes (name):
 # Calculate Distance
 ##################################
 def distance (name):
+  if not is_cg and name in bb_distance.keys():
+    out.write(name)
+    out.write(",")
+    out.write(str(10 * bb_distance[name]))
+    out.write("\n")
+    return
   distance = -1
   for n in find_nodes (name):
     d = 0.0


### PR DESCRIPTION
The paper defines the basic-block-level target distance as follows:
![Definition of basic-block-level-target distance (Equation 2 in AFLGo Paper)](https://user-images.githubusercontent.com/4940804/114991452-e2f7af00-9e99-11eb-9c2f-d62cb06b72e6.png)

However, AFLGo's distance calculation always performs the third case when calling the `distance` function.
It is probably not an issue in most cases. However, it can be problematic. Consider the following CFG with a single node CG (i.e. `test` is the only function). The red basic blocks are the targeted BBs.

<p align="center">
  <img src="https://user-images.githubusercontent.com/4940804/114993386-0facc600-9e9c-11eb-8f5c-664a17b79c9d.png">
</p>


**The current version will calculate:**
a.c:1, a.c:2, a.c:3 distance: 1.9677419354838712
a.c:1, a.c:4, a.c:5, a.c:6, a.c:7, a.c:3 distance: 2.1890160142662927

**The 'fixed' version:**
a.c:1, a.c:2, a.c:3 distance 1.634408602150538
a.c:1, a.c:4, a.c:5, a.c:6, a.c:7, a.c:3 distance: 1.4552995391705073

With the longer path we explore all targets, which is the wished behavior, but the current version assigns a worse distance to this path.

---

The example can be reproduced with the following files:
[example.tar.gz](https://github.com/aflgo/aflgo/files/6323569/example.tar.gz)

```
./distance.py -d callgraph.dot -t ftargets.txt -o cg.dist.txt -n fnames.txt
./distance.py -d test.dot -t bbtargets.txt -o dist.out -n bbnames.txt -c \
              cg.dist.txt -s bbcalls.txt 
./cal_dist.py
```
