### PR TITLE
fix scripts/distance.py

### DIFF
--- a/scripts/distance.py
+++ b/scripts/distance.py
@@ -115,7 +115,7 @@ if __name__ == '__main__':
   G = nx.DiGraph(nx.drawing.nx_pydot.read_dot(args.dot))
   print (nx.info(G))
 
-  is_cg = "Name: Call graph" in nx.info(G)
+  is_cg = "Call graph" in nx.info(G)
   print ("\nWorking in %s mode.." % ("CG" if is_cg else "CFG"))
 
   # Process as ControlFlowGraph


### PR DESCRIPTION
This PR tries to fix call graph detection in distance.py.

I got the same error as #42, but the program outputs `Specify file containing CG-level distance (-c).`

I found that since the output of `nx.info(G)` is `DiGraph named 'Call graph: XXX.0.0.preopt.bc' with 77 nodes and 220 edges`, `is_cg` set to `False`. With `-c` not set, then the distance.py exits.

https://github.com/aflgo/aflgo/blob/25a4f3a8461a5d04651927410a3f58eb4494bc6d/scripts/distance.py#L118

See the latest `nx.info` in [nx.info](https://github.com/networkx/networkx/blob/1ca398b5daa2fbc11e48554f427c8c15a4a1fe50/networkx/classes/function.py#L587-L588) and [str](https://github.com/networkx/networkx/blob/1ca398b5daa2fbc11e48554f427c8c15a4a1fe50/networkx/classes/graph.py#L371-L396).