### PR TITLE
update Readme.md. Add command to filter out incorrect lines in BBcall…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,8 +121,8 @@ echo "Function targets"
 cat $TMP_DIR/Ftargets.txt
 
 # Clean up
-cat $TMP_DIR/BBnames.txt | rev | cut -d: -f2- | rev | sort | uniq > $TMP_DIR/BBnames2.txt && mv $TMP_DIR/BBnames2.txt $TMP_DIR/BBnames.txt
-cat $TMP_DIR/BBcalls.txt | sort | uniq > $TMP_DIR/BBcalls2.txt && mv $TMP_DIR/BBcalls2.txt $TMP_DIR/BBcalls.txt
+cat $TMP_DIR/BBnames.txt | grep -v "^$"| rev | cut -d: -f2- | rev | sort | uniq > $TMP_DIR/BBnames2.txt && mv $TMP_DIR/BBnames2.txt $TMP_DIR/BBnames.txt
+cat $TMP_DIR/BBcalls.txt | grep -Ev "^[^,]*$|^([^,]*,){2,}[^,]*$"| sort | uniq > $TMP_DIR/BBcalls2.txt && mv $TMP_DIR/BBcalls2.txt $TMP_DIR/BBcalls.txt
 
 # Generate distance ☕️
 # $AFLGO/scripts/genDistance.sh is the original, but significantly slower, version


### PR DESCRIPTION
Hi, I have updated `Readme.md` to help fix #97 .

Specifically, I added commands in the cleanup process to filter the empty lines in `BBnames.txt` and lines containing less or more than one comma in `BBcalls.txt`.

```
# Remove empty lines
grep -v "^$"
# Only keep lines with one comma mark
grep -Ev "^[^,]*$|^([^,]*,){2,}[^,]*$"
```