### PR TITLE
Make LLVM 11 compile under Ubuntu 20.04+

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,6 @@ pushd llvm_tools
 wget -O llvm-11.0.0.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-11.0.0.src.tar.xz
 tar -xf llvm-11.0.0.src.tar.xz
 mv      llvm-11.0.0.src        llvm
-sed -i -e 's/#include <vector>/#include <limits>\n#include <vector>/' ./llvm/utils/benchmark/src/benchmark_register.h
 
 wget -O  clang-11.0.0.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang-11.0.0.src.tar.xz
 tar -xf  clang-11.0.0.src.tar.xz
@@ -56,6 +55,10 @@ cmake -G "Ninja" \
       -DLLVM_TARGETS_TO_BUILD="X86" \
       -DLLVM_BINUTILS_INCDIR=/usr/include \
       -DLLVM_ENABLE_PROJECTS="clang;compiler-rt" \
+      -DLLVM_BUILD_TESTS=OFF \
+      -DLLVM_INCLUDE_TESTS=OFF \
+      -DLLVM_BUILD_BENCHMARKS=OFF \
+      -DLLVM_INCLUDE_BENCHMARKS=OFF \
       ../llvm
 ninja; ninja install
 

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,7 @@ pushd llvm_tools
 wget -O llvm-11.0.0.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/llvm-11.0.0.src.tar.xz
 tar -xf llvm-11.0.0.src.tar.xz
 mv      llvm-11.0.0.src        llvm
+sed -i -e 's/#include <vector>/#include <limits>\n#include <vector>/' ./llvm/utils/benchmark/src/benchmark_register.h
 
 wget -O  clang-11.0.0.src.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/clang-11.0.0.src.tar.xz
 tar -xf  clang-11.0.0.src.tar.xz


### PR DESCRIPTION
This should be a non-invasive patch that fixes this: https://github.com/llvm/llvm-project/commit/b498303066a63a203d24f739b2d2e0e56dca70d1 (it just adds `#include <limits>`)
With this patch LLVM 11 compiles under (at least) Ubuntu 20.04, 22.04, and 23.04. (without, LLVM will not compile with newer Ubuntu/gcc versions)