### PR TITLE
make pip installation work with Python 3.11+ (Ubuntu 23.04)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -82,28 +82,40 @@ cp /usr/local/lib/LLVMgold.so /usr/lib/bfd-plugins
 
 $apt_get install -y python3-dev python3-pip pkg-config autoconf automake libtool-bin gawk libboost-all-dev
 
+pip_install="python3 -m pip install"
+pip_install_break="python3 -m pip install --break-system-packages"
+
 # See https://networkx.org/documentation/stable/release/index.html
-case `python3 -c 'import sys; print(sys.version_info[:][1])'` in
+python_minor_version="$(python3 -c 'import sys; print(sys.version_info[:][1])')"
+
+case "$python_minor_version" in
     [01])
-        python3 -m pip install 'networkx<1.9';;
+        networkx_version='networkx<1.9';;
     2)
-        python3 -m pip install 'networkx<1.11';;
+        networkx_version='networkx<1.11';;
     3)
-        python3 -m pip install 'networkx<2.0';;
+        networkx_version='networkx<2.0';;
     4)
-        python3 -m pip install 'networkx<2.2';;
+        networkx_version='networkx<2.2';;
     5)
-        python3 -m pip install 'networkx<2.5';;
+        networkx_version='networkx<2.5';;
     6)
-        python3 -m pip install 'networkx<2.6';;
+        networkx_version='networkx<2.6';;
     7)
-        python3 -m pip install 'networkx<2.7';;
+        networkx_version='networkx<2.7';;
     8)
-        python3 -m pip install 'networkx<=3.1';;
+        networkx_version='networkx<=3.1';;
     *)
-        python3 -m pip install networkx;;
+        networkx_version='networkx';;
 esac
-python3 -m pip install pydot pydotplus
+
+pip_packages="pydot pydotplus"
+
+if [ $python_minor_version -ge 11 ]; then
+        $pip_install_break $networkx_version $pip_packages
+else
+        $pip_install $networkx_version $pip_packages
+fi
 
 ##############################
 ### Build AFLGo components ###


### PR DESCRIPTION
Ubuntu 23.04 ships with Python 3.11. Since that version it is not possible to just run `python3 -m pip install` because of PEP 668 – Marking Python base environments as "externally managed" (https://peps.python.org/pep-0668/)
There are at least two solutions:
1. Use `--break-system-packages` which is the easiest fix, but might also result in breaking the user's system (hence the name ^^)
2. Create a virtual environment. This would be cleaner, but requires to activate the environment every time one wants to use AFLGo's Python scripts (not so convenient)

In the `README.md` there is already this sentence:
> Be careful in these steps we would download, build and install LLVM 11.0.0 from source, which may have unexpected impacts on compiler toolchain in current system.

So we could use 1. as suggested in the patch and just add another note about the `pip` installation. One could also assume that users setup Docker containers for their fuzzing campaigns where it would not matter to "break the system".

In the case of 2. I could introduce a virtual environment which would also work across all Python/Ubuntu versions and would be cleaner. The documentation and example scripts would have to be updated as well.

Another alternative would be to just add a comment about Python 3.11+ versions and leave everything else as it is :)