### PR TITLE
 fixes: #142

### DIFF
--- a/distance/distance_calculator/distance.bin.cc
+++ b/distance/distance_calculator/distance.bin.cc
@@ -80,11 +80,12 @@ inline void init_distances_from(const graph_t &G, vertex_desc from, std::vector<
 
 void distance(
     const graph_t &G,
-    const std::string &name,
+    const std::string &name_temp,
     const std::vector<vertex_desc> &targets,
     std::ofstream &out,
     unordered_map<std::string, double> &bb_distance
 ) {
+    std::string name = name_temp.substr(0, name_temp.size() - 1);
     if (not is_cg and bb_distance.find(name) != bb_distance.end()) {
         out << name << "," << bo::lexical_cast<std::string>(10 * bb_distance[name]) << "\n";
         return;

--- a/distance/distance_calculator/distance.py
+++ b/distance/distance_calculator/distance.py
@@ -53,7 +53,8 @@ def find_nodes (name):
 ##################################
 # Calculate Distance
 ##################################
-def distance (name):
+def distance (name_temp):
+  name = name_temp.strip(":")
   if not is_cg and name in bb_distance.keys():
     out.write(name)
     out.write(",")


### PR DESCRIPTION
The error occurred because the basic block names in BBnames.txt generated during the preprocessing stage have a ":" at the end, and during distance calculation, due to the presence of it, it's unable to find the corresponding key in bb_distance.